### PR TITLE
CI: Removing tests for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ env:
    
 matrix:
     include:
-    - python: 3.5
-      env:
-        - PYTHON_VERSION="3.5"
-        - DOC_BUILD="true"
-        - SKIP_HRRR_TEST="True"
     - python: 3.6
       env:
         - PYTHON_VERSION="3.6"

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -30,6 +30,7 @@ of parallelism we recommend:
 ::
 
 While PyDDA will work on less than this, you may run into performance issues.
+In addition, we do not support Python versions less than 3.6. If you have an older version installed, PyDDA may work just fine but we will not provide support for any issues unless you are using at least Python 3.6.
 
 =========================
 Installation instructions


### PR DESCRIPTION
As of this PR we will no longer support Python 3.5 and focus our testing on Python 3.6 and 3.7.