### PR TITLE
FIX: ERA interim was needing a file even when it didn't

### DIFF
--- a/pydda/initialization/wind_fields.py
+++ b/pydda/initialization/wind_fields.py
@@ -85,8 +85,9 @@ def make_initialization_from_era_interim(Grid, file_name=None, vel_field=None):
                              hour_rounded_to_nearest_3,
                              grid_time.minute, grid_time.second)
 
-    if not os.path.isfile(file_name):
-        raise FileNotFoundError(file_name + " not found!")
+    if file_name is not None:
+        if not os.path.isfile(file_name):
+            raise FileNotFoundError(file_name + " not found!")
 
     if file_name is None:
         print("Download ERA Interim data...")


### PR DESCRIPTION
Fixing an error that was making ERA interim initialization not work when there was no file.