### PR TITLE
PyDDA version 1.1

### DIFF
--- a/pydda/__init__.py
+++ b/pydda/__init__.py
@@ -11,7 +11,7 @@ from . import initialization
 from . import tests
 from . import constraints
 
-__version__ = '1.0.2'
+__version__ = '1.1.0'
 
 print("Welcome to PyDDA 1.0.2")
 print("Detecting Jax...")

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ LONG_DESCRIPTION = "\n".join(DOCLINES[2:])
 LICENSE = 'BSD'
 PLATFORMS = "Linux, Windows, OSX"
 MAJOR = 1
-MINOR = 0
-MICRO = 2
+MINOR = 1
+MICRO = 0
 
 #SCRIPTS = glob.glob('scripts/*')
 #TEST_SUITE = 'nose.collector'


### PR DESCRIPTION
In this release of PyDDA, the most important addition is the implementation of an augmented Lagrangian solver that makes it no longer necessary for the user to select weights for their constraints. We have currently tested the functionality using the radar observation and mass continuity constraints. In order to use this capability, set the engine to "auglag" and the Co and Cm weights to 1.0. This method places a strong constraint that mass continuity must be satisfied everywhere in the domain within a specified tolerance. Given a 0.05 m/s uncertainty in the horizontal winds, our current tolerance of 1e-3 for this threshold will correspond to that level of uncertainty in the wind measurements. Therefore, if you want to allow more room for uncertainty here, the cvtol variable can be adjusted accordingly. I would like to thank @mmenickelly for his wonderful contribution to PyDDA.

In addition, we have fixed a few bugs related to the jax engine not correctly specifying a few variables and have moved to GitHub Actions for CI and document generation.