### PR TITLE
FIX: Mass continuity gradient in TensorFlow and remove

### DIFF
--- a/pydda/retrieval/wind_retrieve.py
+++ b/pydda/retrieval/wind_retrieve.py
@@ -1115,7 +1115,6 @@ def _get_dd_wind_field_tensorflow(
     winds = tfp.optimizer.lbfgs_minimize(
         loss_and_gradient,
         initial_position=winds,
-        f_relative_tolerance=1e-3,
         tolerance=1e-3,
         x_tolerance=wind_tol,
         max_iterations=max_iterations,


### PR DESCRIPTION
I removed the automatic differentiation from the TensorFlow Engine in the mass continuity equation as it was giving zero gradients in the w direction. This caused w to explode to very large values when using the TensorFlow engine.