### PR TITLE
ADD: Need Python 3.10 for doc building

### DIFF
--- a/doc/environment_docs.yml
+++ b/doc/environment_docs.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python
+  - python>=3.10
   - pip
   - arm_pyart
   - cython


### PR DESCRIPTION
Fix doc build by requiring Python 3.10 or greater.