### PR TITLE
FIX: Errors with pydda's read_from_pyart_grid with origin_latitude

### DIFF
--- a/pydda/__init__.py
+++ b/pydda/__init__.py
@@ -12,7 +12,7 @@ from . import tests
 from . import constraints
 from . import io
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 
 print("Welcome to PyDDA %s" % __version__)
 print("If you are using PyDDA in your publications, please cite:")

--- a/pydda/io/read_grid.py
+++ b/pydda/io/read_grid.py
@@ -90,6 +90,11 @@ def read_from_pyart_grid(Grid):
     origin_latitude = Grid.origin_latitude
     origin_longitude = Grid.origin_longitude
     origin_altitude = Grid.origin_altitude
+    # Ensure that origin latitude, longitude are 1-D for .to_xarray()
+
+    origin_latitude["data"] = np.atleast_1d(np.squeeze(origin_latitude["data"]))
+    origin_longitude["data"] = np.atleast_1d(np.squeeze(origin_longitude["data"]))
+    origin_altitude["data"] = np.atleast_1d(np.squeeze(origin_altitude["data"]))
 
     if len(list(Grid.fields.keys())) > 0:
         first_grid_name = list(Grid.fields.keys())[0]

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ LICENSE = "BSD"
 PLATFORMS = "Linux, Windows, OSX"
 MAJOR = 2
 MINOR = 0
-MICRO = 2
+MICRO = 3
 
 # SCRIPTS = glob.glob('scripts/*')
 # TEST_SUITE = 'nose.collector'


### PR DESCRIPTION
pydda's read_from_pyart_grid function was throwing errors when trying to convert origin_latitude, origin_longitude, and origin_altitude from PyART Grids to xarray Grids. This fix bumps PyDDA to 2.0.3 so that this fix can be implemented.