### PR TITLE
Fix radar pair weighting being referenced by cur_array

### DIFF
--- a/pydda/retrieval/wind_retrieve.py
+++ b/pydda/retrieval/wind_retrieve.py
@@ -399,7 +399,7 @@ def _get_dd_wind_field_scipy(
                                 ~parameters.els[j][k].mask,
                             )
                         )
-                        cur_array = parameters.weights[i, k]
+                        cur_array = parameters.weights[i, k].copy()
                         cur_array[
                             np.logical_and(
                                 valid,
@@ -950,7 +950,7 @@ def _get_dd_wind_field_tensorflow(
 
                 for k in range(parameters.vrs[i].shape[0]):
                     if weights_obs is None:
-                        cur_array = parameters.weights[i, k]
+                        cur_array = parameters.weights[i, k].copy()
                         valid = np.logical_and.reduce(
                             (
                                 ~parameters.vrs[i][k].mask,


### PR DESCRIPTION
The change is related to discussion in https://openradar.discourse.group/t/weighting-between-radars/661/2

Tested scipy_engine and showed reasonable coverage after the fix. Changed also the tensorflow part, but do not have required hardware to test tensorflow part.

weight_bg may have similar problem in view of similar structure. However, I have not used that part, and hence not in a position to comment. Also, if bg wind is supplied by users, normally the weighting will also be supplied. Therefore, the weight_bg part is left unchanged.