### PR TITLE
FIX: Correct axis parameters and remove duplicate coefficient scaling…

### DIFF
--- a/pydda/cost_functions/_cost_functions_jax.py
+++ b/pydda/cost_functions/_cost_functions_jax.py
@@ -191,7 +191,7 @@ def calculate_smoothness_cost(u, v, w, dx, dy, dz, Cx=1e-5, Cy=1e-5, Cz=1e-5):
         Cx
         * (
             jnp.gradient(dudx, dx, axis=2)
-            + jnp.gradient(dvdx, dx, axis=1)
+            + jnp.gradient(dvdx, dx, axis=2)
             + jnp.gradient(dwdx, dx, axis=2)
         )
         ** 2
@@ -199,18 +199,18 @@ def calculate_smoothness_cost(u, v, w, dx, dy, dz, Cx=1e-5, Cy=1e-5, Cz=1e-5):
     y_term = (
         Cy
         * (
-            jnp.gradient(dudy, dy, axis=2)
+            jnp.gradient(dudy, dy, axis=1)
             + jnp.gradient(dvdy, dy, axis=1)
-            + jnp.gradient(dwdy, dy, axis=2)
+            + jnp.gradient(dwdy, dy, axis=1)
         )
         ** 2
     )
     z_term = (
         Cz
         * (
-            jnp.gradient(dudz, dz, axis=2)
-            + jnp.gradient(dvdz, dz, axis=1)
-            + jnp.gradient(dwdz, dz, axis=2)
+            jnp.gradient(dudz, dz, axis=0)
+            + jnp.gradient(dvdz, dz, axis=0)
+            + jnp.gradient(dwdz, dz, axis=0)
         )
         ** 2
     )
@@ -253,94 +253,16 @@ def calculate_smoothness_gradient(
     y: float array
         value of gradient of smoothness cost function
     """
-    dudx = jnp.gradient(u, dx, axis=2)
-    dudy = jnp.gradient(u, dy, axis=1)
-    dudz = jnp.gradient(u, dz, axis=0)
-    dvdx = jnp.gradient(v, dx, axis=2)
-    dvdy = jnp.gradient(v, dy, axis=1)
-    dvdz = jnp.gradient(v, dz, axis=0)
-    dwdx = jnp.gradient(w, dx, axis=2)
-    dwdy = jnp.gradient(w, dy, axis=1)
-    dwdz = jnp.gradient(w, dz, axis=0)
-
-    x_term = (
-        Cx
-        * (
-            jnp.gradient(dudx, dx, axis=2)
-            + jnp.gradient(dvdx, dx, axis=1)
-            + jnp.gradient(dwdx, dx, axis=2)
-        )
-        ** 2
+    primals, fun_vjp = jax.vjp(
+        calculate_smoothness_cost, u, v, w, dx, dy, dz, Cx, Cy, Cz
     )
-    y_term = (
-        Cy
-        * (
-            jnp.gradient(dudy, dy, axis=2)
-            + jnp.gradient(dvdy, dy, axis=1)
-            + jnp.gradient(dwdy, dy, axis=2)
-        )
-        ** 2
-    )
-    z_term = (
-        Cz
-        * (
-            jnp.gradient(dudz, dz, axis=2)
-            + jnp.gradient(dvdz, dz, axis=1)
-            + jnp.gradient(dwdz, dz, axis=2)
-        )
-        ** 2
-    )
-
-    du = x_term / dx
-    dv = y_term / dy
-    dw = z_term / dz
-    dudx = jnp.gradient(du, dx, axis=2)
-    dudy = jnp.gradient(du, dy, axis=1)
-    dudz = jnp.gradient(du, dz, axis=0)
-    dvdx = jnp.gradient(dv, dx, axis=2)
-    dvdy = jnp.gradient(dv, dy, axis=1)
-    dvdz = jnp.gradient(dv, dz, axis=0)
-    dwdx = jnp.gradient(dw, dx, axis=2)
-    dwdy = jnp.gradient(dw, dy, axis=1)
-    dwdz = jnp.gradient(dw, dz, axis=0)
-
-    x_term = (
-        Cx
-        * (
-            jnp.gradient(dudx, dx, axis=2)
-            + jnp.gradient(dvdx, dx, axis=1)
-            + jnp.gradient(dwdx, dx, axis=2)
-        )
-        ** 2
-    )
-    y_term = (
-        Cy
-        * (
-            jnp.gradient(dudy, dy, axis=2)
-            + jnp.gradient(dvdy, dy, axis=1)
-            + jnp.gradient(dwdy, dy, axis=2)
-        )
-        ** 2
-    )
-    z_term = (
-        Cz
-        * (
-            jnp.gradient(dudz, dz, axis=2)
-            + jnp.gradient(dvdz, dz, axis=1)
-            + jnp.gradient(dwdz, dz, axis=2)
-        )
-        ** 2
-    )
-
-    grad_u = x_term / dx
-    grad_v = y_term / dy
-    grad_w = z_term / dz
+    grad_u, grad_v, grad_w, _, _, _, _, _, _ = fun_vjp(1.0)
 
     # Impermeability condition
-    grad_w.at[0, :, :].set(0)
+    grad_w = grad_w.at[0, :, :].set(0)
     if upper_bc is True:
-        grad_w.at[-1, :, :].set(0)
-    y = jnp.stack([grad_u * Cx * 2, grad_v * Cy * 2, grad_w * Cz * 2], axis=0)
+        grad_w = grad_w.at[-1, :, :].set(0)
+    y = jnp.stack([grad_u, grad_v, grad_w], axis=0)
 
     return y.flatten()
 

--- a/pydda/cost_functions/_cost_functions_numpy.py
+++ b/pydda/cost_functions/_cost_functions_numpy.py
@@ -183,7 +183,7 @@ def calculate_smoothness_cost(u, v, w, dx, dy, dz, Cx=1e-5, Cy=1e-5, Cz=1e-5):
         Cx
         * (
             np.gradient(dudx, dx, axis=2)
-            + np.gradient(dvdx, dx, axis=1)
+            + np.gradient(dvdx, dx, axis=2)
             + np.gradient(dwdx, dx, axis=2)
         )
         ** 2
@@ -191,18 +191,18 @@ def calculate_smoothness_cost(u, v, w, dx, dy, dz, Cx=1e-5, Cy=1e-5, Cz=1e-5):
     y_term = (
         Cy
         * (
-            np.gradient(dudy, dy, axis=2)
+            np.gradient(dudy, dy, axis=1)
             + np.gradient(dvdy, dy, axis=1)
-            + np.gradient(dwdy, dy, axis=2)
+            + np.gradient(dwdy, dy, axis=1)
         )
         ** 2
     )
     z_term = (
         Cz
         * (
-            np.gradient(dudz, dz, axis=2)
-            + np.gradient(dvdz, dz, axis=1)
-            + np.gradient(dwdz, dz, axis=2)
+            np.gradient(dudz, dz, axis=0)
+            + np.gradient(dvdz, dz, axis=0)
+            + np.gradient(dwdz, dz, axis=0)
         )
         ** 2
     )
@@ -260,7 +260,7 @@ def calculate_smoothness_gradient(
     if upper_bc is True:
         grad_w[-1, :, :] = 0
 
-    y = np.stack([grad_u * Cx * 2, grad_v * Cy * 2, grad_w * Cz * 2], axis=0)
+    y = np.stack([grad_u, grad_v, grad_w], axis=0)
 
     return y.flatten()
 


### PR DESCRIPTION
This commit fixes two critical issues in the smoothness cost and gradient functions:

1. **Fixed incorrect axis parameters in second derivative calculations**:
   - In both JAX and NumPy implementations, the axis parameter was incorrectly specified when computing second derivatives
   - For x-direction terms (Cx), all second derivatives should use axis=2
   - For y-direction terms (Cy), all second derivatives should use axis=1
   - For z-direction terms (Cz), all second derivatives should use axis=0
   - This ensures that second derivatives are taken in the correct spatial direction

2. **Removed duplicate Cx, Cy, Cz scaling in gradient functions**:
   - Both JAX and NumPy gradient functions were incorrectly multiplying by Cx, Cy, Cz coefficients twice
   - The cost function already includes these coefficients, and the gradient (via chain rule or autodiff) inherently includes them
   - Removed the extra `* Cx * 2`, `* Cy * 2`, `* Cz * 2` scaling at the end
   - Also removed the `/dx`, `/dy`, `/dz` operations that were incorrect in JAX

3. **Simplified JAX gradient function**:
   - Removed manual gradient calculation code that duplicated the cost function logic
   - Now relies entirely on JAX's automatic differentiation (vjp) which is more accurate and maintainable
   - Fixed the vjp call to pass Cx, Cy, Cz as positional arguments (not keyword args)

These fixes ensure that the JAX and NumPy/SciPy engines produce consistent results when using smoothness constraints with non-zero Cx, Cy, Cz parameters.

Fixes: https://openradar.discourse.group/t/smoothness-costs-in-different-engines/666