### PR TITLE
FIX: No tensorflow in docs environment. This should fix the issues with building the examples.

### DIFF
--- a/doc/environment_docs.yml
+++ b/doc/environment_docs.yml
@@ -15,8 +15,6 @@ dependencies:
   - cfgrib
   - eccodes
   - sphinx
-  - tensorflow
-  - tensorflow-probability
   - herbie-data
   - nbsphinx
   - pydata-sphinx-theme


### PR DESCRIPTION
The examples were not building due to missing tensorflow libraries. Since tensorflow is not needed for these examples, it has been removed from the doc build environment.