### PR TITLE
ADD: Remove py3.14 for now

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -19,7 +19,7 @@ jobs:
      strategy:
         fail-fast: false
         matrix:
-          python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+          python-version: ["3.10", "3.11", "3.12", "3.13"]
           os: [macOS, ubuntu]
           inlcude:
             - os: macos-latest


### PR DESCRIPTION
Python 3.14 tests are failing due to xarray. Removing for now.